### PR TITLE
Getting ExcelWriter working without a context manager

### DIFF
--- a/1-Data_Prep.ipynb
+++ b/1-Data_Prep.ipynb
@@ -6845,6 +6845,49 @@
     "#     writer.sheets['final_data'].set_column('C:C',14, numformat) ###cant give me correct format, only bold\n",
     "#     writer.sheets['final_data'].set_column('D:D',28)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "outputs": [],
+   "source": [
+    "# Predefine \"fixed\" variables for re-usability\n",
+    "temp = \"data/processed/customer_processed2__formatted.xlsx\"\n",
+    "sheet_name = \"final_data\"\n",
+    "\n",
+    "with pd.ExcelWriter(temp, engine=\"xlsxwriter\") as writer:\n",
+    "    final_data.to_excel(writer, index = False, sheet_name=sheet_name)\n",
+    "\n",
+    "    # Working with pandas, according to docs:\n",
+    "    # https://xlsxwriter.readthedocs.io/working_with_pandas.html\n",
+    "    # Get the xlsxwriter objects from the dataframe writer object.\n",
+    "    # FYI only: Type Hint used here, helps IDE with autocompletion/method suggestions\n",
+    "    # For more on type-hinting: https://realpython.com/lessons/type-hinting/\n",
+    "    workbook: xlsxwriter.workbook.Workbook = writer.book\n",
+    "    worksheet: xlsxwriter.worksheet.Worksheet = writer.sheets[sheet_name]\n",
+    "\n",
+    "    # Define your number format, according to docs:\n",
+    "    # https://xlsxwriter.readthedocs.io/workbook.html#add_format\n",
+    "    # Specifically for num_format, for the available \"Format String\" see (e.g. \"#,##0.00\"):\n",
+    "    # https://xlsxwriter.readthedocs.io/format.html#set_num_format\n",
+    "    # FYI only: There's also another valid way to define specific formats\n",
+    "    #           like \"workbook.add_format().set_num_format('#,##0.00')\".\n",
+    "    #           Advise to ignore for now to avoid confusion.\n",
+    "    # FYI only: Other types of format methods/properties available:\n",
+    "    #           https://xlsxwriter.readthedocs.io/format.html#format-methods-and-format-properties\n",
+    "    num_format = workbook.add_format({'num_format': '#,##0.00'})\n",
+    "\n",
+    "    # Set (specific) column width and or format following docs:\n",
+    "    # https://xlsxwriter.readthedocs.io/worksheet.html#set_column\n",
+    "    worksheet.set_column('C:C',14, num_format)\n",
+    "    worksheet.set_column('D:D',28)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   }
  ],
  "metadata": {

--- a/1-Data_Prep.ipynb
+++ b/1-Data_Prep.ipynb
@@ -6806,8 +6806,31 @@
    "outputs": [],
    "source": [
     "# # why doesn't this work???\n",
-    "# writer = pd.ExcelWriter(output_file2)\n",
-    "# final_data.to_excel(writer, index = False, sheet_name=\"final_data\")"
+    "writer = pd.ExcelWriter(output_file2)\n",
+    "final_data.to_excel(writer, index = False, sheet_name=\"final_data\")\n",
+    "\"\"\"\n",
+    "Solution 1 - Enable original code to work:\n",
+    "  1. Need to add `writer.close()`.\n",
+    "  2. Based on the documentation here: https://pandas.pydata.org/docs/reference/api/pandas.ExcelWriter.html\n",
+    "  3. i.e. \"... Otherwise, call close() to save and close any opened file handles.\"\n",
+    "\"\"\"\n",
+    "writer.close() # <-- need to close\n",
+    "\n",
+    "\"\"\"\n",
+    "Solution 2 - Alternate solution using Context Manager.\n",
+    "  1. Before going any further, note that context manager might be a\n",
+    "     new (advance) concept to grasp. Just know how to use it for now.\n",
+    "  2. But basically, it handles the \"open()\" and \"close()\" of classes.\n",
+    "  3. Note the solution below doesn't need for you to add `writer.close()`.\n",
+    "  4. As a best practice, and as per documentation, using a Context Manager is\n",
+    "     good: \"The writer should be used as a context manager. ...\"\n",
+    "\"\"\"\n",
+    "with pd.ExcelWriter(\"data/processed/using_context_manager.xlsx\") as writer_cm:\n",
+    "    final_data.to_excel(writer_cm)\n",
+    "\n",
+    "\"\"\"\n",
+    "Oh, just noticed, yes the solution below uses a context manager :thumbs_up:\n",
+    "\"\"\""
    ]
   },
   {

--- a/1-Data_Prep.ipynb
+++ b/1-Data_Prep.ipynb
@@ -48,9 +48,9 @@
    "outputs": [],
    "source": [
     "today = datetime.today()\n",
-    "src_file = Path.cwd() / \"data\" / \"raw\" / \"customer_master.xlsx\"\n",
-    "output_file = Path.cwd() / \"data\" / \"processed\" / \"customer_processed.xlsx\"\n",
-    "output_file2 = Path.cwd() / \"data\" / \"processed\" / \"customer_processed2.xlsx\""
+    "src_file = Path.joinpath(Path.cwd(), \"data/raw/customer_master.xlsx\")\n",
+    "output_file = Path.joinpath(Path.cwd(), \"data/processed/customer_processed.xlsx\")\n",
+    "output_file2 = Path.joinpath(Path.cwd(), \"data/processed/customer_processed2.xlsx\")"
    ]
   },
   {

--- a/1-Data_Prep.ipynb
+++ b/1-Data_Prep.ipynb
@@ -6862,7 +6862,7 @@
     "    # https://xlsxwriter.readthedocs.io/working_with_pandas.html\n",
     "    # Get the xlsxwriter objects from the dataframe writer object.\n",
     "    # FYI only: Type Hint used here, helps IDE with autocompletion/method suggestions\n",
-    "    # For more on type-hinting: https://realpython.com/lessons/type-hinting/\n",
+    "    # For more on type-hinting: https://www.infoworld.com/article/3630372/get-started-with-python-type-hints.html\n",
     "    workbook: xlsxwriter.workbook.Workbook = writer.book\n",
     "    worksheet: xlsxwriter.worksheet.Worksheet = writer.sheets[sheet_name]\n",
     "\n",

--- a/1-Data_Prep.ipynb
+++ b/1-Data_Prep.ipynb
@@ -48,9 +48,9 @@
    "outputs": [],
    "source": [
     "today = datetime.today()\n",
-    "src_file = Path.joinpath(Path.cwd(), \"data/raw/customer_master.xlsx\")\n",
-    "output_file = Path.joinpath(Path.cwd(), \"data/processed/customer_processed.xlsx\")\n",
-    "output_file2 = Path.joinpath(Path.cwd(), \"data/processed/customer_processed2.xlsx\")"
+    "src_file = Path.cwd() / \"data\" / \"raw\" / \"customer_master.xlsx\"\n",
+    "output_file = Path.cwd() / \"data\" / \"processed\" / \"customer_processed.xlsx\"\n",
+    "output_file2 = Path.cwd() / \"data\" / \"processed\" / \"customer_processed2.xlsx\""
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+jupyter
+openpyxl
+pandas
+XlsxWriter


### PR DESCRIPTION
# Changes
1. ~Amend source and destination Path variable initialisation/referencing.~ 
2. Solution for the issue with the first implementation of ExcelWriter in notebook.
3. Add simple `requirements.txt`
4. Solution for Number Formatting issue _(see comments in script for more info)_

# (Minor) Github Guide
#### To see the addition/changes in the PR
- Click on "Files changed" tab above this description box:
   <img width="299" alt="Screenshot 2021-12-17 at 10 05 41 PM" src="https://user-images.githubusercontent.com/31307125/146556228-a0925c7c-fb02-4e75-92cd-64dff1e1734e.png">

#### Since it is Jupyter, to see it in a compiled notebook format
- In "File changed" tab, click the `...` and choose "View File"
   <img width="1678" alt="Screenshot 2021-12-17 at 10 07 36 PM" src="https://user-images.githubusercontent.com/31307125/146556457-07f3b0d7-d86b-4b43-ae56-3c95bc1dab80.png">

# Notes
### Comments in Python
- I used `""" ... """` to comment in "blocks" in Python here. But not the best practice.
- Shouldn't have so much comment in the "code" sections, for code cleanliness.
- But this is just to show you an example of and alternate form of comments in Python other than `#`
- Triple quotes usually use for doctrings, for an example see https://github.com/pandas-dev/pandas/blob/v1.3.5/pandas/io/excel/_base.py#L645-L1026 _(this is the source code for the ExcelWriter implementation, if you're interested to see what's going on under the hood)_

### requirements.txt
- Always a good idea to keep a `requirement.txt` file so others or your future self can reproduce _as close as possible_ an environment (with all the modules) in which you ran the script in.
- I created a _simple_ `requirements.txt`, without versions specified for simplicity.
- Reading materials:
  - https://www.idkrtm.com/what-is-the-python-requirements-txt/
  - https://realpython.com/lessons/using-requirement-files/
 

### Context Managers
- Decent explanation: [this](https://www.geeksforgeeks.org/context-manager-in-python/) then [this](https://www.geeksforgeeks.org/with-statement-in-python)
- Detailed explanation: https://realpython.com/python-with-statement/ 

### Type Hinting
- Decent example/usage guide: https://www.jetbrains.com/help/pycharm/type-hinting-in-product.html
- TL;DR basically to tell other users (or remind yourself) what type a Python variable should be, or what a function should return. e.g. Integer? String? Worksheet? Workbook? Dictionary? etc.
   ```py
   
    def return_an_int_from_str(num_string: str) -> int:
        an_integer: int = int(num_string)

        return an_integer
   ```